### PR TITLE
Add geo_ai_agent package structure

### DIFF
--- a/src/geo_ai_agent/__init__.py
+++ b/src/geo_ai_agent/__init__.py
@@ -1,0 +1,28 @@
+"""High level package exporting Geo AI agent components."""
+
+from .agents import Supervisor, GeoQueryAgent
+from .tools import (
+    Tool,
+    SubAgentTool,
+    BedrockAgentCoreTool,
+    MCPServerTool,
+)
+from .core import (
+    AgentType,
+    BedrockAgentCore,
+    MCPServer,
+    configure_logging,
+)
+
+__all__ = [
+    "Supervisor",
+    "GeoQueryAgent",
+    "Tool",
+    "SubAgentTool",
+    "BedrockAgentCoreTool",
+    "MCPServerTool",
+    "AgentType",
+    "BedrockAgentCore",
+    "MCPServer",
+    "configure_logging",
+]

--- a/src/geo_ai_agent/agents/__init__.py
+++ b/src/geo_ai_agent/agents/__init__.py
@@ -1,0 +1,8 @@
+from .supervisor import Supervisor
+from .sub_agents import SubAgent, GeoQueryAgent
+
+__all__ = [
+    "Supervisor",
+    "SubAgent",
+    "GeoQueryAgent",
+]

--- a/src/geo_ai_agent/agents/sub_agents/__init__.py
+++ b/src/geo_ai_agent/agents/sub_agents/__init__.py
@@ -1,0 +1,7 @@
+from .sub_agent import SubAgent
+from .geo_query_agent import GeoQueryAgent
+
+__all__ = [
+    "SubAgent",
+    "GeoQueryAgent",
+]

--- a/src/geo_ai_agent/agents/sub_agents/geo_query_agent/__init__.py
+++ b/src/geo_ai_agent/agents/sub_agents/geo_query_agent/__init__.py
@@ -1,0 +1,3 @@
+from .agent import GeoQueryAgent
+
+__all__ = ["GeoQueryAgent"]

--- a/src/geo_ai_agent/agents/sub_agents/geo_query_agent/agent.py
+++ b/src/geo_ai_agent/agents/sub_agents/geo_query_agent/agent.py
@@ -1,0 +1,10 @@
+"""Simple stub agent that echoes the query it receives."""
+
+from ..sub_agent import SubAgent
+
+
+class GeoQueryAgent(SubAgent):
+    """Pretend agent responding to geo queries."""
+
+    def respond(self, query: str) -> str:
+        return f"Geo query response: {query}"

--- a/src/geo_ai_agent/agents/sub_agents/sub_agent.py
+++ b/src/geo_ai_agent/agents/sub_agents/sub_agent.py
@@ -1,0 +1,12 @@
+"""Interfaces for sub-agents used by the supervisor."""
+
+from abc import ABC, abstractmethod
+
+
+class SubAgent(ABC):
+    """Interface for agents capable of responding to text queries."""
+
+    @abstractmethod
+    def respond(self, query: str) -> str:
+        """Return a response to the provided query."""
+        raise NotImplementedError

--- a/src/geo_ai_agent/agents/supervisor.py
+++ b/src/geo_ai_agent/agents/supervisor.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Dict
+
+from ..tools import Tool
+
+logger = logging.getLogger(__name__)
+
+
+class Supervisor:
+    """Coordinator agent that delegates requests to registered tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Tool] = {}
+
+    def register_tool(self, name: str, tool: Tool) -> None:
+        """Register a tool by name."""
+        self._tools[name] = tool
+        logger.debug("Registered tool %s", name)
+
+    def handle_request(self, tool_name: str, *args, **kwargs) -> str:
+        """Dispatch a request to the specified tool."""
+        tool = self._tools.get(tool_name)
+        if not tool:
+            raise ValueError(f"Unknown tool '{tool_name}'")
+        logger.info("Routing request to tool %s", tool_name)
+        return tool.run(*args, **kwargs)

--- a/src/geo_ai_agent/core/__init__.py
+++ b/src/geo_ai_agent/core/__init__.py
@@ -1,0 +1,24 @@
+from .agent_types import AgentType
+from .logging import configure_logging
+
+
+class BedrockAgentCore:
+    """Simplified stub for Bedrock AgentCore."""
+
+    def execute(self, request: str) -> str:
+        return f"Bedrock executed: {request}"
+
+
+class MCPServer:
+    """Simplified stub for an MCP server."""
+
+    def send_command(self, command: str) -> str:
+        return f"MCP server executed: {command}"
+
+
+__all__ = [
+    "AgentType",
+    "configure_logging",
+    "BedrockAgentCore",
+    "MCPServer",
+]

--- a/src/geo_ai_agent/core/agent_types.py
+++ b/src/geo_ai_agent/core/agent_types.py
@@ -1,0 +1,9 @@
+from enum import Enum, auto
+
+
+class AgentType(Enum):
+    """Enumeration of available agent types."""
+
+    GEO_QUERY = auto()
+    BEDROCK = auto()
+    MCP_SERVER = auto()

--- a/src/geo_ai_agent/core/logging.py
+++ b/src/geo_ai_agent/core/logging.py
@@ -1,0 +1,7 @@
+import logging
+from typing import Optional
+
+
+def configure_logging(level: int = logging.INFO, format: Optional[str] = None) -> None:
+    """Configure basic logging for the package."""
+    logging.basicConfig(level=level, format=format)

--- a/src/geo_ai_agent/main.py
+++ b/src/geo_ai_agent/main.py
@@ -1,0 +1,24 @@
+"""Demonstration of the geo_ai_agent package."""
+
+import logging
+
+from .agents import Supervisor, GeoQueryAgent
+from .core import BedrockAgentCore, MCPServer, configure_logging
+from .tools import SubAgentTool, BedrockAgentCoreTool, MCPServerTool
+
+
+def main() -> None:
+    configure_logging(logging.INFO)
+    agent = Supervisor()
+
+    agent.register_tool("geo_query", SubAgentTool(GeoQueryAgent()))
+    agent.register_tool("bedrock", BedrockAgentCoreTool(BedrockAgentCore()))
+    agent.register_tool("mcp", MCPServerTool(MCPServer()))
+
+    logging.getLogger(__name__).info(agent.handle_request("geo_query", "Hello"))
+    logging.getLogger(__name__).info(agent.handle_request("bedrock", "process"))
+    logging.getLogger(__name__).info(agent.handle_request("mcp", "command"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/geo_ai_agent/tools/__init__.py
+++ b/src/geo_ai_agent/tools/__init__.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+import logging
+from typing import Any
+
+from ..agents.sub_agents.sub_agent import SubAgent
+from ..core import BedrockAgentCore, MCPServer
+
+logger = logging.getLogger(__name__)
+
+
+class Tool(ABC):
+    """Base interface for all tools."""
+
+    @abstractmethod
+    def run(self, *args, **kwargs) -> str:
+        """Execute the tool and return a string result."""
+        raise NotImplementedError
+
+
+class SubAgentTool(Tool):
+    """Tool wrapper for a sub-agent."""
+
+    def __init__(self, agent: SubAgent) -> None:
+        self.agent = agent
+
+    def run(self, query: str) -> str:
+        logger.debug("SubAgentTool received query: %s", query)
+        return self.agent.respond(query)
+
+
+class BedrockAgentCoreTool(Tool):
+    """Tool wrapper for Bedrock AgentCore."""
+
+    def __init__(self, core: BedrockAgentCore) -> None:
+        self.core = core
+
+    def run(self, request: str) -> str:
+        logger.debug("BedrockAgentCoreTool running request: %s", request)
+        return self.core.execute(request)
+
+
+class MCPServerTool(Tool):
+    """Tool wrapper for MCP servers."""
+
+    def __init__(self, server: MCPServer) -> None:
+        self.server = server
+
+    def run(self, command: str) -> str:
+        logger.debug("MCPServerTool sending command: %s", command)
+        return self.server.send_command(command)
+
+
+__all__ = [
+    "Tool",
+    "SubAgentTool",
+    "BedrockAgentCoreTool",
+    "MCPServerTool",
+]


### PR DESCRIPTION
## Summary
- add new `geo_ai_agent` package implementing Supervisor and a simple sub‑agent
- provide core utilities and tools for subagents, bedrock core and MCP server
- include demo `main` script and export components via `__init__`

## Testing
- `PYTHONPATH=src python -m geo_ai_agent.main`

------
https://chatgpt.com/codex/tasks/task_e_687efe04b4ec832587fcc8855b9b8392