### PR TITLE
Simplify component integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ be plugged into a larger agent system.
 
 The entrypoint for the system is a simple `GeoAIAgent` that receives the
 initial request and delegates to registered tools.  Additional sub‑agents or
-servers can easily be added by registering their tools with the agent.
+servers can easily be added by registering their tools with the agent.  
+Version 2 introduces automatic wrapping so you can register components
+directly without manually creating tool wrappers.
 
 ## Example
 Run the examples to see the tools in action:
@@ -38,4 +40,23 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 logger.info(agent.handle_request("upper", "hello"))  # => HELLO
+```
+
+### Integrating sub-agents and servers
+
+You can now register a sub-agent, Bedrock AgentCore, or MCP server directly
+with `GeoAIAgent`.  The agent will wrap the component in the appropriate
+tool automatically:
+
+```python
+from geo_ai_agent import GeoAIAgent, GeoQueryAgent, BedrockAgentCore, MCPServer
+
+agent = GeoAIAgent()
+agent.register_tool("geo", GeoQueryAgent())
+agent.register_tool("bedrock", BedrockAgentCore())
+agent.register_tool("mcp", MCPServer())
+
+agent.handle_request("geo", "hi")      # uses GeoQueryAgent
+agent.handle_request("bedrock", "run")  # uses BedrockAgentCore
+agent.handle_request("mcp", "status")   # uses MCPServer
 ```

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,13 @@ import sys, os
 sys.path.insert(0, os.path.abspath("src"))
 import pytest
 
-from geo_ai_agent import GeoAIAgent
+from geo_ai_agent import (
+    GeoAIAgent,
+    GeoQueryAgent,
+    BedrockAgentCore,
+    MCPServer,
+    StrandsAgent,
+)
 from geo_ai_agent.tools import EchoTool, mcp_status
 
 
@@ -24,4 +30,17 @@ def test_agent_integration():
     assert agent.handle_request("echo", "hi") == "Echo: hi"
     res = agent.handle_request("status")
     assert "MCP server executed" in res
+
+
+def test_auto_wrapping():
+    agent = GeoAIAgent()
+    agent.register_tool("geo", GeoQueryAgent())
+    agent.register_tool("bedrock", BedrockAgentCore())
+    agent.register_tool("mcp", MCPServer())
+    agent.register_tool("strands", StrandsAgent())
+
+    assert "Geo query response" in agent.handle_request("geo", "x")
+    assert "Bedrock executed" in agent.handle_request("bedrock", "cmd")
+    assert "MCP server executed" in agent.handle_request("mcp", "cmd")
+    assert "Strands response" in agent.handle_request("strands", "y")
 


### PR DESCRIPTION
## Summary
- allow GeoAIAgent.register_tool to wrap sub‑agents, cores and servers
- document direct registration in README
- test new automatic wrapping capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f310196d48325a77320b55580153d